### PR TITLE
Path separator compatibility problem

### DIFF
--- a/lib/sass.node.js
+++ b/lib/sass.node.js
@@ -4,6 +4,7 @@
  */
 var fs = require('fs');
 var Sass = require('./sass.sync.js');
+var pathModule = require('path');
 
 function fileExists(path) {
   var stat = fs.statSync(path);
@@ -12,7 +13,7 @@ function fileExists(path) {
 
 function importFileToSass(path, done) {
   // any path must be relative to CWD to work in both environments (real FS, and emscripten FS)
-  var requestedPath = './' + path;
+  var requestedPath = pathModule.normalize('./' + path);
   // figure out the *actual* path of the file
   var filesystemPath = Sass.findPathVariation(fileExists, requestedPath);
   if (!filesystemPath) {


### PR DESCRIPTION
Using external files in MAC
```
@import '../../../css/common/_base.scss';
```
But there was a mistake on the window
```
Error: File "/css/common/_base.scss" not found
```
must change to this
```
@import '..\\..\\..\\css\\common\\_base.scss';
```

## I'm trying to solve it with the ‘path.normalize’
## I will not test this by VScode, so I don't know if it is correct, please confirm!
