### PR TITLE
Fix the Windows relative path problem

### DIFF
--- a/lib/sass.node.js
+++ b/lib/sass.node.js
@@ -4,6 +4,7 @@
  */
 var fs = require('fs');
 var Sass = require('./sass.sync.js');
+var pathModule = require('path');
 
 function fileExists(path) {
   var stat = fs.statSync(path);
@@ -12,7 +13,7 @@ function fileExists(path) {
 
 function importFileToSass(path, done) {
   // any path must be relative to CWD to work in both environments (real FS, and emscripten FS)
-  var requestedPath = './' + path;
+  var requestedPath = pathModule.normalize('./' + path);
   // figure out the *actual* path of the file
   var filesystemPath = Sass.findPathVariation(fileExists, requestedPath);
   if (!filesystemPath) {

--- a/lib/sass.node.js
+++ b/lib/sass.node.js
@@ -4,7 +4,6 @@
  */
 var fs = require('fs');
 var Sass = require('./sass.sync.js');
-var pathModule = require('path');
 
 function fileExists(path) {
   var stat = fs.statSync(path);
@@ -13,7 +12,7 @@ function fileExists(path) {
 
 function importFileToSass(path, done) {
   // any path must be relative to CWD to work in both environments (real FS, and emscripten FS)
-  var requestedPath = pathModule.normalize('./' + path);
+  var requestedPath = './' + path;
   // figure out the *actual* path of the file
   var filesystemPath = Sass.findPathVariation(fileExists, requestedPath);
   if (!filesystemPath) {

--- a/lib/sass.node.spk.js
+++ b/lib/sass.node.spk.js
@@ -41,7 +41,7 @@ function importerCallback(orgPath, request, done) {
 
     var requestedPath;
     if (process.platform == "win32") {
-        requestedPath = request.resolved.replace(/^\/sass\//, '' );
+        requestedPath = request.current.replace(/^\/sass\//, '' );
     } else {
         requestedPath = request.resolved.replace(/^\/sass/, '');
     }


### PR DESCRIPTION
Using external files in MAC
```
@import '../../../css/common/_base.scss';
```
But there was a mistake on the window
```
Error: File "/css/common/_base.scss" not found
``` 

I was debugging on Windows and found that the absolute path was lost.
<img width="562" alt="windows_easysass_debug" src="https://user-images.githubusercontent.com/17250383/33272518-56e4e2fa-d3c5-11e7-90e0-976235c7dc5c.png">
SO ，I switched to 'current' to solve this problem, but I didn't know why chose 'resolved' before.
If I'm not correct, I hope you can solve it, because we need to use it in our project.
thank you