### PR TITLE
Update to Sass.js v0.11.1

### DIFF
--- a/lib/sass.node.js
+++ b/lib/sass.node.js
@@ -1,13 +1,18 @@
-/*! sass.js - v0.10.3 (9802049) - built 2017-01-08
-  providing libsass 3.4.3 (b28de01)
-  via emscripten 1.37.0 ()
+/*! sass.js - v0.11.1 (f286436) - built 2019-10-20
+  providing libsass 3.6.2 (4da7c4bd)
+  via emscripten 1.38.31 (040e49a)
  */
-var fs = require('fs');
 var Sass = require('./sass.sync.js');
+var fs = require('fs');
+var path = require('path');
 
 function fileExists(path) {
   var stat = fs.statSync(path);
   return stat && stat.isFile();
+}
+
+function removeFileExtension(path) {
+  return path.slice(0, path.lastIndexOf('.'));
 }
 
 function importFileToSass(path, done) {
@@ -23,21 +28,25 @@ function importFileToSass(path, done) {
     return;
   }
 
+  // Make sure to omit the ".css" file extension when it was omitted in requestedPath.
+  // This allow raw css imports.
+  // see https://github.com/sass/libsass/pull/754
+  var isRawCss = !requestedPath.endsWith('.css') && filesystemPath.endsWith('.css');
+  var targetPath = isRawCss ? removeFileExtension(filesystemPath) : filesystemPath;
+
   // write the file to emscripten FS so libsass internal FS handling
   // can engage the scss/sass switch, which apparently does not happen
   // for content provided through the importer callback directly
   var content = fs.readFileSync(filesystemPath, {encoding: 'utf8'});
   Sass.writeFile(filesystemPath, content, function() {
     done({
-      path: filesystemPath,
+      path: targetPath,
     });
   });
 }
 
 function importerCallback(request, done) {
-  // sass.js works in the "/sass/" directory, make that relative to CWD
-  var requestedPath = request.resolved.replace(/^\/sass\//, '' );
-  importFileToSass(requestedPath, done);
+  importFileToSass(resolve(request), done);
 }
 
 function compileFile(path, options, callback) {
@@ -50,6 +59,19 @@ function compileFile(path, options, callback) {
   importFileToSass(path, function() {
     Sass.compileFile(path, options, callback);
   });
+}
+
+function resolve(request) {
+  // the request will not have the correct "resolved" path on Windows
+  // see https://github.com/medialize/sass.js/issues/69
+  // see https://github.com/medialize/sass.js/issues/86
+  return path.normalize(
+    path.join(
+      // sass.js works in the "/sass/" directory, make that relative to CWD
+      path.dirname(request.previous.replace(/^\/sass\//, '')),
+      request.current
+    )
+  ).replace(/\\/g, '/');
 }
 
 compileFile.importFileToSass = importFileToSass;


### PR DESCRIPTION
Update to Sass.js v0.11.1 built on 2019-10-20 (from https://github.com/medialize/sass.js/tree/master/dist)

NOTE: I did not update sass.sync.spk.js which it looks like would be needed to complete this update.